### PR TITLE
Fix typo in `help.txt`

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -2,7 +2,7 @@ No Lag v1.1.0
 by supercam19
 https://www.github.com/supercam19/nolag
 
-This text file lists all administarator commands added by this datapack.
+This text file lists all administrator commands added by this datapack.
 OPs(Operators) can run "/function nolag:cmd/help" in game to view all commands.
 
 View file README.md for instructions on how to install and configure the datapack.


### PR DESCRIPTION
Fixes a small typo ("administarator") in [`help.txt`](https://github.com/supercam19/NoLag/blob/e4d9746f0ea6bb1fa1f6c089569e4e05fc0fae17/help.txt#L5).