### PR TITLE
Fix `zip` command from release workflow

### DIFF
--- a/.github/workflows/release_zip.yaml
+++ b/.github/workflows/release_zip.yaml
@@ -23,7 +23,7 @@ jobs:
         run: |
           mkdir NoLag
           cp -r data pack.mcmeta pack.png LICENSE NoLag
-          zip NoLag.zip NoLag/*
+          zip -r NoLag.zip NoLag
           rm -r NoLag
 
       # Uploads the zip with the latest tag appended to the name


### PR DESCRIPTION
Fixes the `zip` command used in PR #6 to be recursive. Previously, it would have only included the `pack.png`, the `pack.mcmeta`, and an empty `data/` directory.